### PR TITLE
images->root

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,8 @@ module.exports = function(grunt) {
         base64image: {
             css: {
                 styles: 'test/styles/',
-                root: 'test/images/',
+                relative: "test/styles",
+                root: 'test/',
                 dest: 'test/dest/'
             }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,8 @@ module.exports = function(grunt) {
         base64image: {
             css: {
                 styles: 'test/styles/',
-                images:'test/images/',
-                dest: 'test/dest/'
+                root  : 'test/images/',
+                dest  : 'test/dest/'
             }
         }
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,8 @@ module.exports = function(grunt) {
         base64image: {
             css: {
                 styles: 'test/styles/',
-                root  : 'test/images/',
-                dest  : 'test/dest/'
+                root: 'test/images/',
+                dest: 'test/dest/'
             }
         }
     });

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ base64image任务使用[css-base64-images](https://github.com/maxzhang/css-base6
 指定CSS源目录
 
 #### root : String
-指定CSS的相对路径，和css-base64-images概念一致。
+指定CSS的路径，和css-base64-images root概念一致。
 比如root 为 a/foo/css
+
 那么在css 中 可以使用 ../image 
-来得到 a/foo/image 路径
+来得到 a/foo/image 这个路径
 
 #### dest : String
 指定输出目录

--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ base64image任务使用[css-base64-images](https://github.com/maxzhang/css-base6
 #### styles : String
 指定CSS源目录
 
-#### images : String
-指定Image源目录
+#### root : String
+指定CSS的相对路径，和css-base64-images概念一致。
+比如root 为 a/foo/css
+那么在css 中 可以使用 ../image 
+来得到 a/foo/image 路径
 
 #### dest : String
-指定输出目录
+指定输出目录，
 
 
 ### Usage Examples
@@ -46,8 +49,8 @@ module.exports = function(grunt) {
         base64image: {
             css: {
                 styles: 'app/styles/',
-                images:'app/images/',
-                dest: 'dest/styles/base64/'
+                root  : 'app/images/',
+                dest  : 'dest/styles/base64/'
             }
         }
     });

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ base64image任务使用[css-base64-images](https://github.com/maxzhang/css-base6
 来得到 a/foo/image 路径
 
 #### dest : String
-指定输出目录，
+指定输出目录
 
 
 ### Usage Examples
@@ -49,8 +49,8 @@ module.exports = function(grunt) {
         base64image: {
             css: {
                 styles: 'app/styles/',
-                root  : 'app/images/',
-                dest  : 'dest/styles/base64/'
+                root: 'app/images/',
+                dest: 'dest/styles/base64/'
             }
         }
     });

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ base64image任务使用[css-base64-images](https://github.com/maxzhang/css-base6
 
 #### styles : String
 指定CSS源目录
+#### relative : String
+指定CSS中相对路径的目录，
+如果没有指定，那么默认采用styles
 
 #### root : String
-指定CSS的路径，和css-base64-images root概念一致。
-比如root 为 a/foo/css
+指定CSS中应用 "/image/a.png" 的根目录
 
-那么在css 中 可以使用 ../image 
-来得到 a/foo/image 这个路径
 
 #### dest : String
 指定输出目录
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
         base64image: {
             css: {
                 styles: 'app/styles/',
-                root: 'app/images/',
+                relative: 'src/images/',
                 dest: 'dest/styles/base64/'
             }
         }

--- a/tasks/base64image.js
+++ b/tasks/base64image.js
@@ -24,22 +24,17 @@ module.exports = function(grunt) {
             promiseArr,
             done;
         this.files.forEach(function(file) {
-            if (grunt.file.exists(file.images)) {
-                done = self.async();
-                promiseArr = [];
-                grunt.file.recurse(file.styles, function(abspath, rootdir, subdir, filename) {
-                    promiseArr.push(base64FromFile(abspath, file.images, path.join(file.dest, subdir || '', filename)));
-                });
-                Promise.all(promiseArr).done(function() {
-                    grunt.log.writeln('Base64 ' + String(promiseArr.length).cyan + ' files');
-                    done();
-                }, function(err) {
-                    grunt.fail.fatal(err);
-                });
-            } else {
-                grunt.log.writeln('No such css file to base64');
-                grunt.file.copy(file.styles, file.dest);
-            }
+            done = self.async();
+            promiseArr = [];
+            grunt.file.recurse(file.styles, function(abspath, rootdir, subdir, filename) {
+                promiseArr.push(base64FromFile(abspath, file.root, path.join(file.dest, subdir || '', filename)));
+            });
+            Promise.all(promiseArr).done(function() {
+                grunt.log.writeln('Base64 ' + String(promiseArr.length).cyan + ' files');
+                done();
+            }, function(err) {
+                grunt.fail.fatal(err);
+            });
         });
     });
 };

--- a/tasks/base64image.js
+++ b/tasks/base64image.js
@@ -6,9 +6,10 @@ module.exports = function(grunt) {
         base64image = require('css-base64-images'),
         Promise = require('promise');
 
-    function base64FromFile(cssFile, imageDir, dest) {
+    function base64FromFile(cssFile, relative,root, dest) {
         return new Promise(function(resolve, reject) {
-            base64image.fromFile(cssFile, imageDir, function(err, css) {
+            var css = fs.readFileSync(cssFile);
+            base64image.fromString(css, relative, root, function(err, css){
                 if (err) {
                     reject(err);
                 } else {
@@ -27,7 +28,8 @@ module.exports = function(grunt) {
             done = self.async();
             promiseArr = [];
             grunt.file.recurse(file.styles, function(abspath, rootdir, subdir, filename) {
-                promiseArr.push(base64FromFile(abspath, file.root, path.join(file.dest, subdir || '', filename)));
+                if(!file.relative) file.relative = file.styles;
+                promiseArr.push(base64FromFile(abspath, file.relative , file.root, path.join(file.dest, subdir || '', filename)));
             });
             Promise.all(promiseArr).done(function() {
                 grunt.log.writeln('Base64 ' + String(promiseArr.length).cyan + ' files');


### PR DESCRIPTION
更换配置中 images 的概念，改成和css-base64-images一致的root。

这么做的原因是有些项目在css中使用相对或者绝对路径，如果强制指定images路径，那么例如
../image 和 /static/image
这样的需求会无法完成。
但是images又不能指定到一个逻辑上存在实际不存在的路径。
为了完成这个需求会需要将images指导一个根本不是放images或者不存在的目录。所以检查images路径是否存在这个操作反而限时了适用范围。
实际上原css-base64-images也有root这个概念。并且代码中也是将images变量直接传给root。所以使用root概念来描述css本身应该在路径，应该更加正确。
